### PR TITLE
Draft: Working on macos support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
         "test": "node --napi-modules ./test/test_binding.js",
         "build:lib": "tsc",
         "build:test": "npm run build && npm test",
-        "build": "cargo-cp-artifact -nc build/xosms-native.node -- cargo build --message-format=json-render-diagnostics",
+        "build": "cargo-cp-artifact -nc build/xosms-native.node -- cargo build --message-format=json-render-diagnostics --target=aarch64-apple-darwin",
         "build-debug": "npm run build --",
         "build-release": "npm run build -- --release",
         "install": "npm run build-release",
         "cargo:test": "cargo test"
     },
     "name": "xosms",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Cross platform media service module. Hooks into each operating system's native media service and provides a simple API to access and use it.",
     "repository": {
         "type": "git",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(type_name_of_val)] //Debug during dev
+
 #[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;


### PR DESCRIPTION
Finally, I found what has been missing in your macOS example - without registered handlers, macOS doesn't render playback info widget.

With the code in this PR, I was able to see test data in playback widget and get debug messages on `commandHandler` invocation.

Unfortunately, current code is just an example with low code quality and I'm still a noob in Rust, so I'm not sure if I would be able to finish this contribution. :(